### PR TITLE
fix a bug when MYSQL_DB be set multiple databases

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -66,7 +66,7 @@ fi
 if [ -n "\${MAX_BACKUPS}" ]; then
 	while [ \$(ls /backup -1 | wc -l) -gt \${MAX_BACKUPS} ];
 	do
-		BACKUP_TO_BE_DELETED=\$(ls /backup -1 | sort | head -n 1)
+		BACKUP_TO_BE_DELETED=\$(ls /backup -1 -t | tail -n 1)
 		echo "   Backup \${BACKUP_TO_BE_DELETED} is deleted"
 		rm -rf /backup/\${BACKUP_TO_BE_DELETED}
 	done


### PR DESCRIPTION
I hava three databases to backup，but it delete the old backup file with wrong。Because the shell command “ls /backup -1 | sort ” sort files by name not by time，so I changed into “ls /backup -1 -t | tail -n 1” then it works！
MYSQL_DB="nacos_config tw_base bjtobacco"